### PR TITLE
Remove reference to `pip install PyQt6-stubs`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,9 @@ Please note that this work is far from complete. You can use the stubs to get ri
 
 # Installation
 
-> WARNING: The Stubs are not yet on pypi
+**WARNING: The Stubs are not yet on pypi**
 
-Simply install PyQt6-stubs with pip:
-
-    $ pip install PyQt6-stubs
-
-Or clone the latest version from Github and install it via Python setuptools:
+Clone the latest version from Github and install it via Python setuptools:
 
     $ git clone https://github.com/TilmanK/PyQt6-stubs
     $ python setup.py install


### PR DESCRIPTION
When ~reading~ only skimming the install instructions one comes around the first suggestion of `pip install PyQt6-stubs`, which we run and we get an error. _Then_ we notice the greyed out warning, curse a little, and follow the only useful instructions. It's a small paper cut, but also a small fix until this lands on PyPI.